### PR TITLE
Update dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,16 +19,16 @@ requirements:
     - pip
   run:
     - python >=3
-    - setuptools >=38.4
-    - matplotlib-base >=3.0
-    - numpy >=1.12
-    - scipy >=0.19
+    - setuptools >=60.0
+    - matplotlib-base >=3.5
+    - numpy >=1.20
+    - scipy >=1.8
     - packaging
-    - pandas >=0.23
-    - xarray >=0.16.1
+    - pandas >=1.4
+    - xarray >=0.21.0
     - netcdf4
-    - typing_extensions >=3.7.4.3
-    - xarray-einstats >=0.2
+    - typing_extensions >=4.1.0
+    - xarray-einstats >=0.3
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 65816761fd2a864e5da08c8663adf7260cd8c904933a88f3b86f2c1ed7510d5e
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:


### PR DESCRIPTION
match current dependencies from https://github.com/arviz-devs/arviz/blob/main/requirements.txt

Otherwise I get the error "AttributeError: module 'matplotlib' has no attribute 'colormaps'" if matplotlib is too old (3.3).


<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
