### PR TITLE
set matplotlib-base >=3.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 35bab9072f66f5a8204d2a71911d09ce05056c177f1a780de53efa2714c27575
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -20,7 +20,7 @@ requirements:
   run:
     - python >=3.9
     - setuptools >=60.0
-    - matplotlib-base >=3.2
+    - matplotlib-base >=3.5
     - numpy >=1.21,<2.0
     - scipy >=1.8
     - packaging


### PR DESCRIPTION
* set matplotlib-base >=3.5 Since https://github.com/arviz-devs/arviz/pull/2127 `arviz/__init__.py` requires matplotlib >= 3.5 for `mpl.colormaps.register()` otherwise `arviz` fails on import.

* update build number

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
