### PR TITLE
Update v0.17.1 release with pinned scipy version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "arviz" %}
-{% set version = "0.18.0" %}
+{% set version = "0.17.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 2ffd6a632af6b28eb5dac7e3b938223ffa202308dc67c58b55a404565a985bd2
+  sha256: b46dc693e34fd3dff20d824234c7a01cb04b1b536441e285218c54fab42c3c09
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -18,18 +18,17 @@ requirements:
     - python >=3
     - pip
   run:
-    - python >=3.10
+    - python >=3.9
     - setuptools >=60.0
     - matplotlib-base >=3.5
-    - numpy >=1.23,<2.0
-    - scipy >=1.9
+    - numpy >=1.22,<2.0
+    - scipy >=1.9,<1.13
     - packaging
-    - pandas >=1.5
-    - xarray >=2022.6.0
+    - pandas >=1.4
+    - xarray >=0.21.0
     - h5netcdf >=1.0.2
     - typing_extensions >=4.1.0
     - xarray-einstats >=0.3
-    - dm-tree >=0.1.8
 
 test:
   imports:


### PR DESCRIPTION
Would it be possible to update the release for v0.17.1 with scipy pinned to <1.13 to avoid https://github.com/arviz-devs/arviz/issues/2336 for conda-forge installs on Python 3.9?

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
